### PR TITLE
Fix KS4U: reject content after document end

### DIFF
--- a/src/parser.zig
+++ b/src/parser.zig
@@ -3679,12 +3679,11 @@ pub const Parser = struct {
             if (self.lexer.isEOF() or self.isAtDocumentMarker()) {
                 continue;
             }
-            
-            // If there's more content without explicit markers, it might be another bare document
-            // But for now, let's be conservative and stop here
-            break;
+
+            // Any other content after a complete document is invalid
+            return error.InvalidContentAfterDocumentEnd;
         }
-        
+
         return stream;
     }
 };

--- a/test_ks4u.zig
+++ b/test_ks4u.zig
@@ -1,0 +1,23 @@
+const std = @import("std");
+const parser = @import("src/parser.zig");
+
+pub fn main() !void {
+    const input =
+        \\---
+        \\[
+        \\sequence item
+        \\]
+        \\invalid item
+    ;
+
+    std.debug.print("Testing KS4U: Invalid content after document end\n", .{});
+    std.debug.print("Input:\n{s}\n", .{input});
+
+    var result = parser.parse(input) catch |err| {
+        std.debug.print("PASS: Parser correctly rejected with error: {}\n", .{err});
+        return;
+    };
+    defer result.deinit();
+
+    std.debug.print("FAIL: Parser accepted invalid YAML\n", .{});
+}


### PR DESCRIPTION
## Summary
- error if extra content appears after finishing a document
- add regression test for KS4U case

## Testing
- `./zig/zig run test_ks4u.zig`
- `./zig/zig build test-yaml -- zig`


------
https://chatgpt.com/codex/tasks/task_e_68950b4d9710832d813a1b7ce36e93e4