### PR TITLE
Fix carriage return line handling in lexer

### DIFF
--- a/.github/workflows/test-zig-parser.yml
+++ b/.github/workflows/test-zig-parser.yml
@@ -110,14 +110,18 @@ jobs:
             # If tests failed, show which ones
             if grep -q "failed" unit-test-output.txt; then
               echo "" >> $GITHUB_STEP_SUMMARY
-              echo "Failed tests:" >> $GITHUB_STEP_SUMMARY
+              echo "#### Failed tests:" >> $GITHUB_STEP_SUMMARY
               echo '```' >> $GITHUB_STEP_SUMMARY
               grep "error:" unit-test-output.txt | grep "test\." | head -10 >> $GITHUB_STEP_SUMMARY || true
               echo '```' >> $GITHUB_STEP_SUMMARY
               
               # Extract failing test names for PR comment
               echo "FAILING_UNIT_TESTS<<EOF" >> $GITHUB_ENV
-              grep "error:" unit-test-output.txt | grep "test\." | sed "s/.*test\.\(.*\)'.*/  - \1/" | head -10 >> $GITHUB_ENV || true
+              # Look for test failures in both build output and parser test details
+              if [ -f parser-test-details.txt ]; then
+                grep "FAIL" parser-test-details.txt | sed 's/.*test\.\(.*\)\.\.\./  - \1/' | head -10 >> $GITHUB_ENV || true
+              fi
+              grep "'.*' failed:" unit-test-output.txt | sed "s/.*'\(.*\)' failed.*/  - \1/" | head -10 >> $GITHUB_ENV || true
               echo "EOF" >> $GITHUB_ENV
             fi
           else
@@ -197,15 +201,32 @@ jobs:
             }
           }
           
+          // Parse unit test summary for better formatting
+          let unitTestDisplay = unitTestSummary;
+          if (unitTestSummary.includes('Build Summary:')) {
+            // Extract the numbers from "Build Summary: X/Y steps succeeded; A/B tests passed"
+            const match = unitTestSummary.match(/(\d+)\/(\d+) tests passed(?:; (\d+) failed)?/);
+            if (match) {
+              const passed = match[1];
+              const total = match[2];
+              const failed = match[3] || '0';
+              if (failed === '0') {
+                unitTestDisplay = `✅ **${passed}/${total}** tests passed`;
+              } else {
+                unitTestDisplay = `⚠️ **${passed}/${total}** tests passed, **${failed}** failed`;
+              }
+            }
+          }
+          
           let commentBody = `## ${statusEmoji} Test Results
           
           ${statusText}
           
           ### Unit Tests
-          ${unitTestSummary}`;
+          ${unitTestDisplay}`;
           
           if (failingUnitTests.trim()) {
-            commentBody += `\n\n**Failing Unit Tests:**\n${failingUnitTests}`;
+            commentBody += `\n\n**Failing tests:**\n${failingUnitTests}`;
           }
           
           commentBody += `\n\n### YAML Test Suite
@@ -218,7 +239,7 @@ jobs:
           }
           
           if (failingTests.trim()) {
-            commentBody += `\n\n### Failing Tests\n${failingTests}`;
+            commentBody += `\n\n**Failing tests:**\n${failingTests}`;
           }
           
           // Add a hidden marker to identify our bot comments

--- a/.github/workflows/test-zig-parser.yml
+++ b/.github/workflows/test-zig-parser.yml
@@ -50,6 +50,10 @@ jobs:
       run: |
         zig build
     
+    - name: Run unit tests
+      run: |
+        zig build test --summary all
+    
     - name: Run YAML test suite
       run: |
         zig build test-yaml -- zig
@@ -57,8 +61,21 @@ jobs:
     - name: Generate test report
       if: always()
       run: |
+        # Capture unit test results
+        zig build test --summary all 2>&1 | tee unit-test-results.txt
+        
+        # Capture YAML test suite results
         zig build test-yaml -- zig --verbose > test-results.txt 2>&1
-        echo "## YAML Test Suite Results" >> $GITHUB_STEP_SUMMARY
+        
+        # Add to GitHub step summary
+        echo "## Test Results" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### Unit Tests" >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+        tail -5 unit-test-results.txt >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### YAML Test Suite" >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
         tail -20 test-results.txt >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
@@ -74,6 +91,10 @@ jobs:
         grep "^  - " test-results.txt | head -20 >> $GITHUB_ENV
         echo "EOF" >> $GITHUB_ENV
         
+        # Extract unit test summary
+        UNIT_TEST_SUMMARY=$(grep "Build Summary:" unit-test-results.txt || echo "Unit tests: unknown")
+        echo "UNIT_TEST_SUMMARY=$UNIT_TEST_SUMMARY" >> $GITHUB_ENV
+        
         # Get baseline passing tests (from main branch)
         echo "BASELINE_PASSING=395" >> $GITHUB_ENV
     
@@ -85,6 +106,7 @@ jobs:
           const passing = process.env.PASSING || 'N/A';
           const failing = process.env.FAILING || 'N/A';
           const failingTests = process.env.FAILING_TESTS || '';
+          const unitTestSummary = process.env.UNIT_TEST_SUMMARY || 'Unit tests: not run';
           const baseline = parseInt(process.env.BASELINE_PASSING || '395');
           const currentPassing = parseInt(passing.split(' ')[0]) || 0;
           const improvement = currentPassing - baseline;
@@ -105,11 +127,14 @@ jobs:
             }
           }
           
-          let commentBody = `## ${statusEmoji} YAML Test Suite Results
+          let commentBody = `## ${statusEmoji} Test Results
           
           ${statusText}
           
-          ### Summary
+          ### Unit Tests
+          ${unitTestSummary}
+          
+          ### YAML Test Suite
           - **Passing**: ${passing}
           - **Failing**: ${failing}
           - **Baseline**: ${baseline} passing`;

--- a/.github/workflows/test-zig-parser.yml
+++ b/.github/workflows/test-zig-parser.yml
@@ -204,8 +204,8 @@ jobs:
               overallEmoji = unitTestHasFailed ? '⚠️' : '🚀';
               overallStatus = unitTestHasFailed ? 'Making progress, but some unit tests failing' : 'Test improvements!';
             } else {
-              yamlStatus = '📊 No change from baseline';
-              overallEmoji = unitTestHasFailed ? '⚠️' : '📊';
+              yamlStatus = 'No change from baseline';
+              overallEmoji = unitTestHasFailed ? '⚠️' : '✓';
               overallStatus = unitTestHasFailed ? 'Unit test failures' : 'No changes';
             }
           } else {

--- a/.github/workflows/test-zig-parser.yml
+++ b/.github/workflows/test-zig-parser.yml
@@ -64,30 +64,30 @@ jobs:
         # Capture YAML test suite results
         zig build test-yaml -- zig --verbose > test-results.txt 2>&1 || true
         
-        # Run cross-parser unit tests
-        zig build test-unit -- zig > unit-test-results.txt 2>&1 || true
-        
         # Add to GitHub step summary
         echo "## Test Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         
-        # Report unit test summary
-        echo "### Unit Tests (Cross-Parser Validation)" >> $GITHUB_STEP_SUMMARY
-        echo '```' >> $GITHUB_STEP_SUMMARY
-        tail -20 unit-test-results.txt >> $GITHUB_STEP_SUMMARY
-        echo '```' >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        
-        # Report individual test failures from zig test
-        echo "### Native Zig Tests" >> $GITHUB_STEP_SUMMARY
-        if grep -q "All .* tests passed" unit-test-output.txt; then
-          echo "✅ All tests passed!" >> $GITHUB_STEP_SUMMARY
+        # Report unit test summary from zig build test
+        echo "### Unit Tests" >> $GITHUB_STEP_SUMMARY
+        if [ -f unit-test-output.txt ]; then
+          if grep -q "All .* tests passed" unit-test-output.txt; then
+            echo "✅ All tests passed!" >> $GITHUB_STEP_SUMMARY
+            UNIT_TEST_SUMMARY="✅ All unit tests passed"
+          elif grep -q "Build Summary:" unit-test-output.txt; then
+            # Extract summary from build output
+            SUMMARY=$(grep "Build Summary:" unit-test-output.txt | head -1)
+            echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY
+            UNIT_TEST_SUMMARY="$SUMMARY"
+          else
+            echo "Unit tests ran with issues. Check logs for details." >> $GITHUB_STEP_SUMMARY
+            UNIT_TEST_SUMMARY="Unit tests: check logs for details"
+          fi
         else
-          echo "Failed tests:" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          grep "error:" unit-test-output.txt | head -10 >> $GITHUB_STEP_SUMMARY || echo "No errors captured" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "Unit tests were not run." >> $GITHUB_STEP_SUMMARY
+          UNIT_TEST_SUMMARY="Unit tests: not run"
         fi
+        echo "UNIT_TEST_SUMMARY=$UNIT_TEST_SUMMARY" >> $GITHUB_ENV
         echo "" >> $GITHUB_STEP_SUMMARY
         
         # Report YAML test suite
@@ -107,15 +107,8 @@ jobs:
         grep "^  - " test-results.txt | head -20 >> $GITHUB_ENV
         echo "EOF" >> $GITHUB_ENV
         
-        # Extract unit test summary
-        UNIT_PASSING=$(grep "Passing:" unit-test-results.txt | awk '{print $2}')
-        UNIT_FAILING=$(grep "Failing:" unit-test-results.txt | awk '{print $2}')
-        UNIT_TOTAL=$(grep "Total tests:" unit-test-results.txt | awk '{print $3}')
-        echo "UNIT_TEST_SUMMARY=Unit tests: $UNIT_PASSING/$UNIT_TOTAL passing" >> $GITHUB_ENV
-        
-        # Extract failing unit test names if any
+        # No separate failing unit tests extraction since we use zig build test
         echo "FAILING_UNIT_TESTS<<EOF" >> $GITHUB_ENV
-        sed -n '/Failing tests:/,/Success rate:/p' unit-test-results.txt | grep "^  - " | head -10 >> $GITHUB_ENV || true
         echo "EOF" >> $GITHUB_ENV
         
         # Get baseline passing tests (from main branch)

--- a/.github/workflows/test-zig-parser.yml
+++ b/.github/workflows/test-zig-parser.yml
@@ -238,8 +238,6 @@ jobs:
           
           ${overallStatus}
           
-          ---
-          
           ### 🧪 Unit Tests
           ${unitTestDisplay}`;
           

--- a/.github/workflows/test-zig-parser.yml
+++ b/.github/workflows/test-zig-parser.yml
@@ -46,13 +46,40 @@ jobs:
       with:
         version: 0.14.1
     
-    - name: Build Zig parser
+    - name: Setup Node.js for TypeScript parser
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    
+    - name: Setup Rust for Rust parser
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+    
+    - name: Build parsers for testing
       run: |
+        # Build Zig parser
         zig build
+        
+        # Build TypeScript parser
+        cd yaml-ts
+        npm install
+        npm run build || true  # Allow to fail if already built
+        cd ..
+        
+        # Build Rust parser
+        cd yaml-rs-test
+        cargo build --release
+        cd ..
     
     - name: Run unit tests
       run: |
+        # Run tests and capture both stdout and stderr
         zig build test --summary all 2>&1 | tee unit-test-output.txt || true
+        
+        # Also run parser tests directly to get detailed output if they fail
+        zig test src/parser_tests.zig 2>&1 | tee parser-test-details.txt || true
     
     - name: Run YAML test suite
       run: |
@@ -79,6 +106,20 @@ jobs:
             SUMMARY=$(grep "Build Summary:" unit-test-output.txt | head -1)
             echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY
             UNIT_TEST_SUMMARY="$SUMMARY"
+            
+            # If tests failed, show which ones
+            if grep -q "failed" unit-test-output.txt; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "Failed tests:" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              grep "error:" unit-test-output.txt | grep "test\." | head -10 >> $GITHUB_STEP_SUMMARY || true
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              
+              # Extract failing test names for PR comment
+              echo "FAILING_UNIT_TESTS<<EOF" >> $GITHUB_ENV
+              grep "error:" unit-test-output.txt | grep "test\." | sed "s/.*test\.\(.*\)'.*/  - \1/" | head -10 >> $GITHUB_ENV || true
+              echo "EOF" >> $GITHUB_ENV
+            fi
           else
             echo "Unit tests ran with issues. Check logs for details." >> $GITHUB_STEP_SUMMARY
             UNIT_TEST_SUMMARY="Unit tests: check logs for details"
@@ -87,6 +128,18 @@ jobs:
           echo "Unit tests were not run." >> $GITHUB_STEP_SUMMARY
           UNIT_TEST_SUMMARY="Unit tests: not run"
         fi
+        
+        # Add parser test details if available
+        if [ -f parser-test-details.txt ]; then
+          if grep -q "failed" parser-test-details.txt; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Parser Test Details:" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            grep -E "^\d+/\d+.*\.\.\." parser-test-details.txt | grep -v "OK" | head -10 >> $GITHUB_STEP_SUMMARY || true
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi
+        fi
+        
         echo "UNIT_TEST_SUMMARY=$UNIT_TEST_SUMMARY" >> $GITHUB_ENV
         echo "" >> $GITHUB_STEP_SUMMARY
         

--- a/.github/workflows/test-zig-parser.yml
+++ b/.github/workflows/test-zig-parser.yml
@@ -52,7 +52,7 @@ jobs:
     
     - name: Run unit tests
       run: |
-        zig build test --summary all
+        zig build test --summary all 2>&1 | tee unit-test-output.txt || true
     
     - name: Run YAML test suite
       run: |
@@ -61,20 +61,36 @@ jobs:
     - name: Generate test report
       if: always()
       run: |
-        # Capture unit test results
-        zig build test --summary all 2>&1 | tee unit-test-results.txt
-        
         # Capture YAML test suite results
-        zig build test-yaml -- zig --verbose > test-results.txt 2>&1
+        zig build test-yaml -- zig --verbose > test-results.txt 2>&1 || true
+        
+        # Run cross-parser unit tests
+        zig build test-unit -- zig > unit-test-results.txt 2>&1 || true
         
         # Add to GitHub step summary
         echo "## Test Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "### Unit Tests" >> $GITHUB_STEP_SUMMARY
+        
+        # Report unit test summary
+        echo "### Unit Tests (Cross-Parser Validation)" >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
-        tail -5 unit-test-results.txt >> $GITHUB_STEP_SUMMARY
+        tail -20 unit-test-results.txt >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
+        
+        # Report individual test failures from zig test
+        echo "### Native Zig Tests" >> $GITHUB_STEP_SUMMARY
+        if grep -q "All .* tests passed" unit-test-output.txt; then
+          echo "✅ All tests passed!" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "Failed tests:" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          grep "error:" unit-test-output.txt | head -10 >> $GITHUB_STEP_SUMMARY || echo "No errors captured" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+        fi
+        echo "" >> $GITHUB_STEP_SUMMARY
+        
+        # Report YAML test suite
         echo "### YAML Test Suite" >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
         tail -20 test-results.txt >> $GITHUB_STEP_SUMMARY
@@ -92,12 +108,14 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
         
         # Extract unit test summary
-        UNIT_TEST_SUMMARY=$(grep "Build Summary:" unit-test-results.txt || echo "Unit tests: unknown")
-        echo "UNIT_TEST_SUMMARY=$UNIT_TEST_SUMMARY" >> $GITHUB_ENV
+        UNIT_PASSING=$(grep "Passing:" unit-test-results.txt | awk '{print $2}')
+        UNIT_FAILING=$(grep "Failing:" unit-test-results.txt | awk '{print $2}')
+        UNIT_TOTAL=$(grep "Total tests:" unit-test-results.txt | awk '{print $3}')
+        echo "UNIT_TEST_SUMMARY=Unit tests: $UNIT_PASSING/$UNIT_TOTAL passing" >> $GITHUB_ENV
         
         # Extract failing unit test names if any
         echo "FAILING_UNIT_TESTS<<EOF" >> $GITHUB_ENV
-        grep "error: '.*' failed:" unit-test-results.txt | sed "s/error: '\(.*\)' failed:.*/  - \1/" | head -10 >> $GITHUB_ENV || true
+        sed -n '/Failing tests:/,/Success rate:/p' unit-test-results.txt | grep "^  - " | head -10 >> $GITHUB_ENV || true
         echo "EOF" >> $GITHUB_ENV
         
         # Get baseline passing tests (from main branch)

--- a/.github/workflows/test-zig-parser.yml
+++ b/.github/workflows/test-zig-parser.yml
@@ -236,6 +236,8 @@ jobs:
           
           let commentBody = `## ${overallEmoji} Test Results
           
+          ___
+          
           ${overallStatus}
           
           ---

--- a/.github/workflows/test-zig-parser.yml
+++ b/.github/workflows/test-zig-parser.yml
@@ -236,8 +236,6 @@ jobs:
           
           let commentBody = `## ${overallEmoji} Test Results
           
-          ___
-          
           ${overallStatus}
           
           ---

--- a/.github/workflows/test-zig-parser.yml
+++ b/.github/workflows/test-zig-parser.yml
@@ -238,6 +238,8 @@ jobs:
           
           ${overallStatus}
           
+          ---
+          
           ### 🧪 Unit Tests
           ${unitTestDisplay}`;
           

--- a/.github/workflows/test-zig-parser.yml
+++ b/.github/workflows/test-zig-parser.yml
@@ -185,20 +185,36 @@ jobs:
           const currentPassing = parseInt(passing.split(' ')[0]) || 0;
           const improvement = currentPassing - baseline;
           
-          let statusEmoji = '✅';
-          let statusText = 'All tests passing!';
+          // Determine overall status based on both test suites
+          let overallEmoji = '✅';
+          let overallStatus = 'All tests passing!';
           
+          // Check unit test status
+          const unitTestHasFailed = unitTestSummary.includes('failed') && !unitTestSummary.includes('0 failed');
+          
+          // Check YAML test suite status
+          let yamlStatus = '';
           if (failing !== '0' && failing !== 'N/A') {
             if (currentPassing < baseline) {
-              statusEmoji = '❌';
-              statusText = `Regression detected! ${baseline - currentPassing} fewer tests passing than baseline.`;
+              yamlStatus = `❌ Regression: ${baseline - currentPassing} fewer tests passing than baseline`;
+              overallEmoji = '❌';
+              overallStatus = 'Test regressions detected';
             } else if (currentPassing > baseline) {
-              statusEmoji = '🚀';
-              statusText = `Progress! ${improvement} more tests passing than baseline.`;
+              yamlStatus = `🚀 Progress: ${improvement} more tests passing than baseline`;
+              overallEmoji = unitTestHasFailed ? '⚠️' : '🚀';
+              overallStatus = unitTestHasFailed ? 'Making progress, but some unit tests failing' : 'Test improvements!';
             } else {
-              statusEmoji = '📊';
-              statusText = 'No change from baseline.';
+              yamlStatus = '📊 No change from baseline';
+              overallEmoji = unitTestHasFailed ? '⚠️' : '📊';
+              overallStatus = unitTestHasFailed ? 'Unit test failures' : 'No changes';
             }
+          } else {
+            yamlStatus = '✅ All YAML tests passing!';
+          }
+          
+          if (unitTestHasFailed && overallEmoji === '✅') {
+            overallEmoji = '⚠️';
+            overallStatus = 'Unit test failures';
           }
           
           // Parse unit test summary for better formatting
@@ -218,21 +234,23 @@ jobs:
             }
           }
           
-          let commentBody = `## ${statusEmoji} Test Results
+          let commentBody = `## ${overallEmoji} Test Results
           
-          ${statusText}
+          ${overallStatus}
           
-          ### Unit Tests
+          ---
+          
+          ### 🧪 Unit Tests
           ${unitTestDisplay}`;
           
           if (failingUnitTests.trim()) {
             commentBody += `\n\n**Failing tests:**\n${failingUnitTests}`;
           }
           
-          commentBody += `\n\n### YAML Test Suite
-          - **Passing**: ${passing}
-          - **Failing**: ${failing}
-          - **Baseline**: ${baseline} passing`;
+          commentBody += `\n\n---\n\n### 📋 YAML Test Suite\n${yamlStatus}\n\n`;
+          commentBody += `- **Passing**: ${passing}\n`;
+          commentBody += `- **Failing**: ${failing}\n`;
+          commentBody += `- **Baseline**: ${baseline} passing`;
           
           if (improvement > 0) {
             commentBody += `\n- **Improvement**: +${improvement} tests now passing! 🎉`;

--- a/.github/workflows/test-zig-parser.yml
+++ b/.github/workflows/test-zig-parser.yml
@@ -95,6 +95,11 @@ jobs:
         UNIT_TEST_SUMMARY=$(grep "Build Summary:" unit-test-results.txt || echo "Unit tests: unknown")
         echo "UNIT_TEST_SUMMARY=$UNIT_TEST_SUMMARY" >> $GITHUB_ENV
         
+        # Extract failing unit test names if any
+        echo "FAILING_UNIT_TESTS<<EOF" >> $GITHUB_ENV
+        grep "error: '.*' failed:" unit-test-results.txt | sed "s/error: '\(.*\)' failed:.*/  - \1/" | head -10 >> $GITHUB_ENV || true
+        echo "EOF" >> $GITHUB_ENV
+        
         # Get baseline passing tests (from main branch)
         echo "BASELINE_PASSING=397" >> $GITHUB_ENV
     
@@ -107,6 +112,7 @@ jobs:
           const failing = process.env.FAILING || 'N/A';
           const failingTests = process.env.FAILING_TESTS || '';
           const unitTestSummary = process.env.UNIT_TEST_SUMMARY || 'Unit tests: not run';
+          const failingUnitTests = process.env.FAILING_UNIT_TESTS || '';
           const baseline = parseInt(process.env.BASELINE_PASSING || '397');
           const currentPassing = parseInt(passing.split(' ')[0]) || 0;
           const improvement = currentPassing - baseline;
@@ -132,9 +138,13 @@ jobs:
           ${statusText}
           
           ### Unit Tests
-          ${unitTestSummary}
+          ${unitTestSummary}`;
           
-          ### YAML Test Suite
+          if (failingUnitTests.trim()) {
+            commentBody += `\n\n**Failing Unit Tests:**\n${failingUnitTests}`;
+          }
+          
+          commentBody += `\n\n### YAML Test Suite
           - **Passing**: ${passing}
           - **Failing**: ${failing}
           - **Baseline**: ${baseline} passing`;

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,10 @@ zig
 worktrees/
 yaml-rs-test/target
 yaml-rs-test/yaml-rs-test
+.tmp/# Test files
+test*.yaml
+test_*.zig
+node_modules/
+package.json
+pnpm-lock.yaml
 .tmp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,41 @@ Successfully fixed 40+ tests in recent commits:
 
 ## Testing
 
+### Unit Tests
+
+The project includes unit tests that validate parser behavior across multiple implementations:
+
+```bash
+# Run all unit tests (includes cross-parser validation)
+./zig/zig build test
+
+# Run unit tests directly to see test names
+./zig/zig test src/parser_tests.zig
+
+# Run with filter to match specific tests
+./zig/zig test src/parser_tests.zig --test-filter "parser:"
+```
+
+#### Understanding Unit Test Output
+
+- Tests validate against Zig, TypeScript, and Rust parsers
+- When parsers disagree, you'll see notes like:
+  ```
+  Note: TypeScript parser disagrees (got true, expected false)
+  Note: Rust parser disagrees (got false, expected true)
+  ```
+- These notes help identify spec ambiguities where parsers have made different choices
+- Tests document actual behavior, not necessarily "correct" behavior
+
+#### Unit Test Structure
+
+- Test files follow pattern: `<module>_tests.zig` (e.g., `parser_tests.zig`)
+- Each test validates behavior across all three parsers
+- Helper functions `testTypescriptParser()` and `testRustParser()` invoke external parsers
+- Tests only fail if the Zig parser doesn't match expected behavior
+
+### YAML Test Suite
+
 ```bash
 # Run full test suite
 ./zig/zig build test-yaml -- zig

--- a/build.zig
+++ b/build.zig
@@ -114,6 +114,14 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     const run_parser_tests = b.addRunArtifact(parser_tests);
+    
+    // Add comprehensive parser tests that validate against multiple parsers
+    const parser_validation_tests = b.addTest(.{
+        .root_source_file = b.path("src/parser_tests.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const run_parser_validation_tests = b.addRunArtifact(parser_validation_tests);
 
     const lexer_tests = b.addTest(.{
         .root_source_file = b.path("src/lexer.zig"),
@@ -136,6 +144,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_lib_unit_tests.step);
     test_step.dependOn(&run_exe_unit_tests.step);
     test_step.dependOn(&run_parser_tests.step);
+    test_step.dependOn(&run_parser_validation_tests.step);
     test_step.dependOn(&run_lexer_tests.step);
     test_step.dependOn(&run_ast_tests.step);
     

--- a/build.zig
+++ b/build.zig
@@ -107,12 +107,37 @@ pub fn build(b: *std.Build) void {
 
     const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
 
+    // Add tests for individual source files
+    const parser_tests = b.addTest(.{
+        .root_source_file = b.path("src/parser.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const run_parser_tests = b.addRunArtifact(parser_tests);
+
+    const lexer_tests = b.addTest(.{
+        .root_source_file = b.path("src/lexer.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const run_lexer_tests = b.addRunArtifact(lexer_tests);
+
+    const ast_tests = b.addTest(.{
+        .root_source_file = b.path("src/ast.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const run_ast_tests = b.addRunArtifact(ast_tests);
+
     // Similar to creating the run step earlier, this exposes a `test` step to
     // the `zig build --help` menu, providing a way for the user to request
     // running the unit tests.
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_lib_unit_tests.step);
     test_step.dependOn(&run_exe_unit_tests.step);
+    test_step.dependOn(&run_parser_tests.step);
+    test_step.dependOn(&run_lexer_tests.step);
+    test_step.dependOn(&run_ast_tests.step);
     
     // Add YAML test runner
     const test_runner = b.addExecutable(.{

--- a/src/lexer.zig
+++ b/src/lexer.zig
@@ -29,14 +29,24 @@ pub const Lexer = struct {
     pub fn advance(self: *Lexer, count: usize) void {
         var i: usize = 0;
         while (i < count and self.pos < self.input.len) : (i += 1) {
-            if (self.input[self.pos] == '\n') {
+            const ch = self.input[self.pos];
+            if (ch == '\n') {
                 self.line += 1;
                 self.column = 1;
-                self.line_start = self.pos + 1;
+                self.pos += 1;
+                self.line_start = self.pos;
+            } else if (ch == '\r') {
+                self.line += 1;
+                self.column = 1;
+                self.pos += 1;
+                if (self.pos < self.input.len and self.input[self.pos] == '\n') {
+                    self.pos += 1;
+                }
+                self.line_start = self.pos;
             } else {
                 self.column += 1;
+                self.pos += 1;
             }
-            self.pos += 1;
         }
     }
     
@@ -82,13 +92,7 @@ pub const Lexer = struct {
     
     pub fn skipLineBreak(self: *Lexer) bool {
         const ch = self.peek();
-        if (ch == '\r') {
-            self.advanceChar();
-            if (self.peek() == '\n') {
-                self.advanceChar();
-            }
-            return true;
-        } else if (ch == '\n') {
+        if (ch == '\r' or ch == '\n') {
             self.advanceChar();
             return true;
         }

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -3813,3 +3813,18 @@ pub fn parse(input: []const u8) ParseError!ast.Document {
         };
     }
 }
+
+test "parser handles CR line endings" {
+    const input = "key1: value1\rkey2: value2\r";
+    var doc = try parse(input);
+    defer doc.deinit();
+    try std.testing.expect(doc.root != null);
+    const root = doc.root.?;
+    try std.testing.expect(root.type == .mapping);
+    const map = root.data.mapping;
+    try std.testing.expectEqual(@as(usize, 2), map.pairs.items.len);
+    try std.testing.expectEqualStrings("key1", map.pairs.items[0].key.data.scalar.value);
+    try std.testing.expectEqualStrings("value1", map.pairs.items[0].value.data.scalar.value);
+    try std.testing.expectEqualStrings("key2", map.pairs.items[1].key.data.scalar.value);
+    try std.testing.expectEqualStrings("value2", map.pairs.items[1].value.data.scalar.value);
+}

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -3829,3 +3829,25 @@ test "parser handles CR line endings" {
     try std.testing.expectEqualStrings("value2", map.pairs.items[1].value.data.scalar.value);
 }
 
+test "CI test - should fail to check reporting" {
+    const input = "foo: bar";
+    var doc = try parse(input);
+    defer doc.deinit();
+    
+    // This will fail - expecting wrong value
+    const root = doc.root.?;
+    const map = root.data.mapping;
+    try std.testing.expectEqualStrings("WRONG_VALUE", map.pairs.items[0].value.data.scalar.value);
+}
+
+test "CI test 2 - another failure for testing" {
+    const input = "test: 123";
+    var doc = try parse(input);
+    defer doc.deinit();
+    
+    // This will also fail - expecting wrong key
+    const root = doc.root.?;
+    const map = root.data.mapping;
+    try std.testing.expectEqualStrings("different_key", map.pairs.items[0].key.data.scalar.value);
+}
+

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -3829,14 +3829,3 @@ test "parser handles CR line endings" {
     try std.testing.expectEqualStrings("value2", map.pairs.items[1].value.data.scalar.value);
 }
 
-test "intentionally failing test to check CI output" {
-    const input = "test: value";
-    var doc = try parse(input);
-    defer doc.deinit();
-    try std.testing.expect(doc.root != null);
-    const root = doc.root.?;
-    try std.testing.expect(root.type == .mapping);
-    const map = root.data.mapping;
-    // This should fail - expecting wrong value
-    try std.testing.expectEqualStrings("wrong_value", map.pairs.items[0].value.data.scalar.value);
-}

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -3829,25 +3829,4 @@ test "parser handles CR line endings" {
     try std.testing.expectEqualStrings("value2", map.pairs.items[1].value.data.scalar.value);
 }
 
-test "CI test - should fail to check reporting" {
-    const input = "foo: bar";
-    var doc = try parse(input);
-    defer doc.deinit();
-    
-    // This will fail - expecting wrong value
-    const root = doc.root.?;
-    const map = root.data.mapping;
-    try std.testing.expectEqualStrings("WRONG_VALUE", map.pairs.items[0].value.data.scalar.value);
-}
-
-test "CI test 2 - another failure for testing" {
-    const input = "test: 123";
-    var doc = try parse(input);
-    defer doc.deinit();
-    
-    // This will also fail - expecting wrong key
-    const root = doc.root.?;
-    const map = root.data.mapping;
-    try std.testing.expectEqualStrings("different_key", map.pairs.items[0].key.data.scalar.value);
-}
 

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -3828,3 +3828,15 @@ test "parser handles CR line endings" {
     try std.testing.expectEqualStrings("key2", map.pairs.items[1].key.data.scalar.value);
     try std.testing.expectEqualStrings("value2", map.pairs.items[1].value.data.scalar.value);
 }
+
+test "intentionally failing test to check CI output" {
+    const input = "test: value";
+    var doc = try parse(input);
+    defer doc.deinit();
+    try std.testing.expect(doc.root != null);
+    const root = doc.root.?;
+    try std.testing.expect(root.type == .mapping);
+    const map = root.data.mapping;
+    // This should fail - expecting wrong value
+    try std.testing.expectEqualStrings("wrong_value", map.pairs.items[0].value.data.scalar.value);
+}

--- a/src/parser_tests.zig
+++ b/src/parser_tests.zig
@@ -142,7 +142,8 @@ test "parser: simple key-value mapping" {
 
 test "parser: intentionally failing test for CI" {
     // This test should fail to show CI formatting
-    try validateWithAllParsers("invalid: { broken yaml", true);
+    // Using an actually invalid YAML that all parsers reject
+    try testing.expectEqual(@as(u32, 1), @as(u32, 2));
 }
 
 test "parser: nested mapping" {

--- a/src/parser_tests.zig
+++ b/src/parser_tests.zig
@@ -143,3 +143,9 @@ test "parser: simple key-value mapping" {
 test "parser: nested mapping" {
     try validateWithAllParsers("parent:\n  child: value", false);
 }
+
+// Intentionally failing test to verify CI reporting
+test "parser: intentionally failing test for CI verification" {
+    // This should fail - we're expecting it to reject but it will accept
+    try validateWithAllParsers("valid: yaml", true);
+}

--- a/src/parser_tests.zig
+++ b/src/parser_tests.zig
@@ -140,6 +140,11 @@ test "parser: simple key-value mapping" {
     try validateWithAllParsers("key: value", false);
 }
 
+test "parser: intentionally failing test for CI" {
+    // This test should fail to show CI formatting
+    try validateWithAllParsers("invalid: { broken yaml", true);
+}
+
 test "parser: nested mapping" {
     try validateWithAllParsers("parent:\n  child: value", false);
 }

--- a/src/parser_tests.zig
+++ b/src/parser_tests.zig
@@ -140,11 +140,6 @@ test "parser: simple key-value mapping" {
     try validateWithAllParsers("key: value", false);
 }
 
-test "parser: intentionally failing test for CI" {
-    // This test should fail to show CI formatting
-    // Using an actually invalid YAML that all parsers reject
-    try testing.expectEqual(@as(u32, 1), @as(u32, 2));
-}
 
 test "parser: nested mapping" {
     try validateWithAllParsers("parent:\n  child: value", false);

--- a/src/parser_tests.zig
+++ b/src/parser_tests.zig
@@ -1,0 +1,132 @@
+const std = @import("std");
+const parser = @import("parser.zig");
+const testing = std.testing;
+
+// Helper function to test with TypeScript parser
+fn testTypescriptParser(yaml_input: []const u8) !bool {
+    const allocator = testing.allocator;
+
+    // Create .tmp directory if it doesn't exist
+    const cwd = std.fs.cwd();
+    cwd.makeDir(".tmp") catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+
+    // Write yaml input to a temp file
+    const tmp_path = ".tmp/test_input.yaml";
+    const tmp_file = try cwd.createFile(tmp_path, .{});
+    defer tmp_file.close();
+    defer cwd.deleteFile(tmp_path) catch {};
+
+    try tmp_file.writeAll(yaml_input);
+
+    // Use TypeScript yaml parser to test
+    const result = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &[_][]const u8{
+            "bun",
+            "-e",
+            \\const fs = require('fs');
+            \\const yaml = require('./yaml-ts/dist/index.js');
+            \\const input = fs.readFileSync(process.argv[1], 'utf8');
+            \\try {
+            \\  const docs = yaml.parseAllDocuments(input);
+            \\  let errors = [];
+            \\  for (const doc of docs) errors = errors.concat(doc.errors);
+            \\  if (errors.length > 0) {
+            \\    process.exit(1);
+            \\  }
+            \\  process.exit(0);
+            \\} catch (e) {
+            \\  process.exit(1);
+            \\}
+            ,
+            tmp_path,
+        },
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    return result.term.Exited == 0;
+}
+
+// Helper function to test with Rust parser
+fn testRustParser(yaml_input: []const u8) !bool {
+    const allocator = testing.allocator;
+
+    // Create .tmp directory if it doesn't exist
+    const cwd = std.fs.cwd();
+    cwd.makeDir(".tmp") catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+
+    // Write yaml input to a temp file
+    const yaml_path = ".tmp/test_input_rust.yaml";
+    const yaml_file = try cwd.createFile(yaml_path, .{});
+    defer yaml_file.close();
+    defer cwd.deleteFile(yaml_path) catch {};
+    try yaml_file.writeAll(yaml_input);
+
+    // Run the pre-built Rust parser binary
+    const result = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &[_][]const u8{
+            "./yaml-rs-test/target/release/yaml-rs-test",
+            yaml_path,
+        },
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    return result.term.Exited == 0;
+}
+
+// Helper to validate a test case across all parsers
+fn validateWithAllParsers(input: []const u8, should_fail: bool) !void {
+    // Test with Zig parser
+    const zig_result = if (parser.parse(input)) |_| true else |_| false;
+
+    // Test with TypeScript parser
+    const ts_result = try testTypescriptParser(input);
+
+    // Test with Rust parser
+    const rust_result = try testRustParser(input);
+
+    const expected = !should_fail;
+
+    // Log if other parsers disagree (but don't fail the test)
+    if (ts_result != expected) {
+        std.debug.print("\n  Note: TypeScript parser disagrees (got {}, expected {})\n", .{ ts_result, expected });
+    }
+
+    if (rust_result != expected) {
+        std.debug.print("\n  Note: Rust parser disagrees (got {}, expected {})\n", .{ rust_result, expected });
+    }
+
+    // Zig parser must match expected
+    try testing.expectEqual(expected, zig_result);
+}
+
+// Basic scalar tests
+test "parser: simple scalar value" {
+    try validateWithAllParsers("hello", false);
+}
+
+test "parser: double-quoted scalar" {
+    try validateWithAllParsers("\"hello world\"", false);
+}
+
+test "parser: single-quoted scalar" {
+    try validateWithAllParsers("'hello world'", false);
+}
+
+// Basic mapping tests
+test "parser: simple key-value mapping" {
+    try validateWithAllParsers("key: value", false);
+}
+
+test "parser: nested mapping" {
+    try validateWithAllParsers("parent:\n  child: value", false);
+}

--- a/src/parser_tests.zig
+++ b/src/parser_tests.zig
@@ -143,9 +143,3 @@ test "parser: simple key-value mapping" {
 test "parser: nested mapping" {
     try validateWithAllParsers("parent:\n  child: value", false);
 }
-
-// Intentionally failing test to verify CI reporting
-test "parser: intentionally failing test for CI verification" {
-    // This should fail - we're expecting it to reject but it will accept
-    try validateWithAllParsers("valid: yaml", true);
-}


### PR DESCRIPTION
## Summary
- handle Windows-style and CR-only line breaks in lexer
- test parser against YAML input with CR line endings

## Testing
- `zig test src/parser.zig` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68951488fa04832fb28c41c3f6d41f94