### PR TITLE
Reject content after document end

### DIFF
--- a/src/parser.zig
+++ b/src/parser.zig
@@ -3776,10 +3776,9 @@ pub const Parser = struct {
             if (self.lexer.isEOF() or self.isAtDocumentMarker()) {
                 continue;
             }
-            
-            // If there's more content without explicit markers, it might be another bare document
-            // But for now, let's be conservative and stop here
-            break;
+
+            // Any other content at the root level after a document is invalid
+            return error.InvalidContentAfterDocumentEnd;
         }
         
         return stream;


### PR DESCRIPTION
## Summary
- error on any extra content after a YAML document

## Testing
- `./zig/zig test src/parser_tests.zig`
- `./zig/zig build test-yaml -- zig --verbose`


------
https://chatgpt.com/codex/tasks/task_b_68952ff4a85c832f8fbe2bbe34f2a6e9