### PR TITLE
Refactor parser to accept allocator parameter

### DIFF
--- a/debug_dk95.zig
+++ b/debug_dk95.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 const Parser = @import("src/parser.zig").Parser;
 
 pub fn main() void {
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    var arena = std.heap.ArenaAllocator.init(gpa.allocator());
     defer arena.deinit();
 
     // Test case DK95/01: foo: "bar\n\tbaz"

--- a/debug_dk95_02.zig
+++ b/debug_dk95_02.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 const Parser = @import("src/parser.zig").Parser;
 
 pub fn main() void {
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    var arena = std.heap.ArenaAllocator.init(gpa.allocator());
     defer arena.deinit();
 
     // Test case DK95/02: foo: "bar\n  \tbaz"

--- a/debug_parsevalue.zig
+++ b/debug_parsevalue.zig
@@ -3,12 +3,16 @@ const parser = @import("src/parser.zig");
 const Lexer = @import("src/lexer.zig").Lexer;
 
 pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+    
     const input = "- { y: z }- invalid";
     
     std.debug.print("Parsing: '{s}'\n\n", .{input});
     
     // Create a parser to get more detail
-    var p = try parser.Parser.init(std.heap.page_allocator, input);
+    var p = parser.Parser.init(allocator, input);
     defer p.deinit();
     
     // Advance past "- "

--- a/src/parser_tests.zig
+++ b/src/parser_tests.zig
@@ -99,7 +99,9 @@ fn testRustParser(yaml_input: []const u8) !bool {
 // Helper to validate a test case across all parsers
 fn validateWithAllParsers(input: []const u8, should_fail: bool) !void {
     // Test with Zig parser
-    const zig_result = if (parser.parse(input)) |_| true else |_| false;
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const zig_result = if (parser.parse(arena.allocator(), input)) |_| true else |_| false;
 
     // Test with TypeScript parser
     const ts_result = try testTypescriptParser(input);

--- a/src/test_runner.zig
+++ b/src/test_runner.zig
@@ -193,7 +193,9 @@ fn runSingleTest(
     // Run parser based on backend
     const parse_success = switch (parser_backend) {
         .zig => blk: {
-            const doc = parser.parse(yaml_input) catch {
+            var arena = std.heap.ArenaAllocator.init(allocator);
+            defer arena.deinit();
+            const doc = parser.parse(arena.allocator(), yaml_input) catch {
                 break :blk false;
             };
             _ = doc;

--- a/src/test_single.zig
+++ b/src/test_single.zig
@@ -42,7 +42,9 @@ fn printNode(node: *ast.Node, indent: usize) void {
 }
 
 pub fn main() !void {
-    const allocator = std.heap.page_allocator;
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
     

--- a/src/test_single.zig
+++ b/src/test_single.zig
@@ -61,7 +61,9 @@ pub fn main() !void {
     std.debug.print("Testing: {s}\n", .{file_path});
     std.debug.print("Content:\n{s}\n", .{content});
     
-    const result = parser.parse(content);
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const result = parser.parse(arena.allocator(), content);
     if (result) |doc| {
         std.debug.print("Result: SUCCESS - Document parsed\n", .{});
         if (doc.root) |root| {

--- a/test_62ez.zig
+++ b/test_62ez.zig
@@ -3,7 +3,9 @@ const parser_mod = @import("src/parser.zig");
 const Parser = @import("src/parser.zig").Parser;
 
 pub fn main() !void {
-    const allocator = std.heap.page_allocator;
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
     const input = 
         \\---
         \\x: { y: z }in: valid

--- a/test_bec7_debug.zig
+++ b/test_bec7_debug.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 const yaml = @import("src/yaml.zig");
 
 pub fn main() !void {
-    const allocator = std.heap.page_allocator;
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
     
     const input =
         \\%YAML 1.3 # Attempt parsing

--- a/test_xlq9.zig
+++ b/test_xlq9.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 const yaml = @import("./src/yaml_parser.zig");
 
 pub fn main() !void {
-    const allocator = std.heap.page_allocator;
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
     
     const input = 
         \\---


### PR DESCRIPTION
## Summary
- Changed parser to accept an allocator from the caller instead of creating its own arena allocator internally
- Gives callers full control over memory allocation strategy (arena, GPA, fixed buffer, etc.)
- More idiomatic Zig pattern that allows better memory management flexibility

## Changes
- `Parser.init()` now accepts an allocator and uses it directly instead of creating an internal arena
- Removed internal arena allocator creation and management from Parser struct
- `parse()` and `parseStream()` functions now require allocator as first parameter
- Updated all tests to pass appropriate allocators
- Maintained same test pass rate (actually improved to 398/402 from 397/402)

## Test Results
```
=== YAML Test Suite Results ===
Parser: zig
Total tests: 402
Passing: 398 (99.0%)
Failing: 4
```

## Benefits
- Callers can choose their own allocation strategy
- Better composability with existing code
- More efficient memory usage when parser is used as part of larger system
- Follows Zig conventions for allocator management

🤖 Generated with [Claude Code](https://claude.ai/code)