### PR TITLE
Detect stray content after document

### DIFF
--- a/src/parser.zig
+++ b/src/parser.zig
@@ -3927,15 +3927,18 @@ pub const Parser = struct {
             if (!has_document_end and !self.lexer.isEOF() and self.lexer.peek() == '%') {
                 return error.DirectiveAfterContent;
             }
-            
-            // If we're at another document marker or EOF, continue
-            if (self.lexer.isEOF() or self.isAtDocumentMarker()) {
-                continue;
+
+            // After skipping whitespace, any additional non-marker content
+            // indicates an invalid document structure (9CWY).
+            if (!self.lexer.isEOF() and !self.isAtDocumentMarker()) {
+                return error.InvalidDocumentStructure;
             }
 
-            // If there's more content without explicit markers, it might be another bare document
-            // But for now, let's be conservative and stop here
-            break;
+            // At this point we're either at EOF or a document marker.
+            if (self.lexer.isEOF()) break;
+
+            // Continue parsing the next document marker.
+            continue;
         }
 
         return stream;


### PR DESCRIPTION
## Summary
- report `InvalidDocumentStructure` when additional top-level content follows a document without a `---` or `...` marker

## Testing
- `./zig/zig test src/parser.zig`
- `./zig-out/bin/yaml-test-runner zig`


------
https://chatgpt.com/codex/tasks/task_b_6895607cc6f0832fade6ae1632d89fbb