### PR TITLE
Add check for stray root-level tokens

### DIFF
--- a/src/parser.zig
+++ b/src/parser.zig
@@ -3921,21 +3921,21 @@ pub const Parser = struct {
             
             // Skip whitespace and comments but preserve document markers
             self.skipWhitespaceAndCommentsButNotDocumentMarkers();
-            
+
             // Check if we have a directive after content - this is invalid
             // BUT only if we didn't have a proper document end marker
             if (!has_document_end and !self.lexer.isEOF() and self.lexer.peek() == '%') {
                 return error.DirectiveAfterContent;
             }
-            
-            // If we're at another document marker or EOF, continue
-            if (self.lexer.isEOF() or self.isAtDocumentMarker()) {
-                continue;
+
+            // After a document, ensure any remaining tokens are either a document marker or EOF.
+            // If we find additional content, that's an invalid document structure.
+            if (!self.lexer.isEOF() and !self.isAtDocumentMarker()) {
+                return error.InvalidDocumentStructure;
             }
 
-            // If there's more content without explicit markers, it might be another bare document
-            // But for now, let's be conservative and stop here
-            break;
+            // Otherwise, we're at EOF or a new document marker; continue parsing
+            continue;
         }
 
         return stream;


### PR DESCRIPTION
## Summary
- detect extra top-level content following a document and raise InvalidDocumentStructure

## Testing
- `./zig/zig build test-yaml -- zig`

------
https://chatgpt.com/codex/tasks/task_b_6895607cc6f0832fade6ae1632d89fbb